### PR TITLE
Fix lang default value logic

### DIFF
--- a/src/Helper/Lang.php
+++ b/src/Helper/Lang.php
@@ -31,7 +31,7 @@ class Lang {
 		
 		if(empty(self::$lang) && Auth::get_lang()) {
 			self::$lang = Auth::get_lang();
-		} else {
+		} else if (empty(self::$lang)) {
 			self::$lang = self::DEFAULT_LANG;
 		}
 


### PR DESCRIPTION
Only use fallback value if global constant and Auth::get_lang() returns nothing.