### PR TITLE
Update dependency from unsecure JWT-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ext-mysqli": "*",
 		"webbmaffian/orm": "^2.0.0",
 		"josegonzalez/dotenv": "^3.0.0",
-		"firebase/php-jwt": "^6.0",
+		"firebase/php-jwt": "^7.0",
 		"malios/php-to-ascii-table": "^3.0.0"
 	}
 }


### PR DESCRIPTION
Usage in this repo should be unaffected, the only risk is using too short/weak JWT_SECRET in ENV.